### PR TITLE
libsel4vmmplatsupport: Fix an off-by-one error

### DIFF
--- a/libsel4vmmplatsupport/src/ioports.c
+++ b/libsel4vmmplatsupport/src/ioports.c
@@ -102,7 +102,7 @@ static int add_io_port_range(vmm_io_port_list_t *io_list, ioport_entry_t *port)
     }
     /* ensure this range does not overlap */
     for (int i = 0; i < io_list->num_ioports; i++) {
-        if (io_list->ioports[i]->range.end > port->range.start && io_list->ioports[i]->range.start < port->range.end) {
+        if (io_list->ioports[i]->range.end >= port->range.start && io_list->ioports[i]->range.start <= port->range.end) {
             ZF_LOGE("Requested ioport range 0x%x-0x%x for %s overlaps with existing range 0x%x-0x%x for %s",
                     port->range.start, port->range.end, port->interface.desc ? port->interface.desc : "Unknown IO Port",
                     io_list->ioports[i]->range.start, io_list->ioports[i]->range.end,
@@ -130,7 +130,7 @@ static int alloc_free_io_port_range(vmm_io_port_list_t *io_list, ioport_range_t 
     }
     io_list->alloc_addr += io_range->size;
     io_range->start = free_port_addr;
-    io_range->end = free_port_addr + io_range->size;
+    io_range->end = free_port_addr + io_range->size - 1;
     return 0;
 }
 


### PR DESCRIPTION
Previously, the 'end' of an IO port range was not inclusive. This would
result in a bug where one IO port whose value is the 'end' of a range
would be mistaken as being part of that range when it should not be.
This commit fixes it so that the 'end' of an IO port range is now
inclusive. Also harden the range overlap check.

This fixes this issue raised in http://sel4.systems/pipermail/devel/2020-March/002708.html.